### PR TITLE
fix(env): enable es6 env

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 module.exports = {
   env: {
+    'es6': true,
     'mocha': true,
     'node': true
   },

--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ module.exports = {
     'no-var': 2,
     'no-with': 2,
     'object-curly-spacing': [2, 'always'],
-    'object-shorthand': 2,
+    'object-shorthand': [2, 'properties'],
     'one-var': [2, 'never'],
     'operator-linebreak': [2, 'after'],
     'prefer-arrow-callback': 2,


### PR DESCRIPTION
* I want to be able to remove the explicit specification of es6 from our `.eslintrc` and it still works, so it needs that in the config as well.
* We said that we didn't want to enforce method shorthand, only property shorthand.

@mgartner 