### PR TITLE
fix(arrow-body-style): remove the buggy rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,6 @@ module.exports = {
   },
   rules: {
     'array-bracket-spacing': [2, 'never'],
-    'arrow-body-style': [2, 'as-needed'],
     'arrow-parens': 2,
     'arrow-spacing': 2,
     'block-spacing': [2, 'always'],


### PR DESCRIPTION
I'm disabling this rule because of an [eslint bug](https://github.com/eslint/eslint/issues/4411) that causes it complain about empty arrow bodies, like [here](https://github.com/lob/hapi-bookshelf-total-count/pull/1/files#diff-0fd0e07cf6d02bf7cf00f18cebb8e6eaR33). It's been fixed in the later eslint version but that version has breaking changes that affect a bunch of other rules. So this is temporary until we update the linter to the latest version of eslint and update our rules accordingly.