### PR TITLE
fix(max-lines): reduce it from 2 to 1

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -53,7 +53,7 @@ module.exports = {
     'no-lonely-if': 2,
     'no-mixed-spaces-and-tabs': [2, 'smart-tabs'],
     'no-multi-str': 2,
-    'no-multiple-empty-lines': [2, { max: 2 }],
+    'no-multiple-empty-lines': [2, { max: 1 }],
     'no-negated-in-lhs': 2,
     'no-new': 2,
     'no-obj-calls': 2,

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ module.exports = {
     'no-loop-func': 2,
     'no-mixed-spaces-and-tabs': [2, 'smart-tabs'],
     'no-multi-str': 2,
-    'no-multiple-empty-lines': [2, { max: 2 }],
+    'no-multiple-empty-lines': [2, { max: 1 }],
     'no-negated-in-lhs': 2,
     'no-new': 2,
     'no-obj-calls': 2,


### PR DESCRIPTION
It's currently set to 2 so 

```js
const hello = 'world';


const banana = 'phone';
```

is valid. But it shouldn't be.