### PR TITLE
fix(key-spacing): use strict mode

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -21,7 +21,7 @@ module.exports = {
     'eol-last': 2,
     'eqeqeq': 2,
     'indent': [2, 2, { 'SwitchCase': 1 }],
-    'key-spacing': [2, { 'beforeColon': false, 'afterColon': true, 'mode': 'minimum' }],
+    'key-spacing': [2, { 'beforeColon': false, 'afterColon': true, 'mode': 'strict' }],
     'linebreak-style': [2, 'unix'],
     'new-parens': 2,
     'no-caller': 2,

--- a/es5.js
+++ b/es5.js
@@ -20,7 +20,7 @@ module.exports = {
     'eol-last': 2,
     'eqeqeq': 2,
     'indent': [2, 2, { 'SwitchCase': 1 }],
-    'key-spacing': [2, { 'beforeColon': false, 'afterColon': true, 'mode': 'minimum' }],
+    'key-spacing': [2, { 'beforeColon': false, 'afterColon': true, 'mode': 'strict' }],
     'linebreak-style': [2, 'unix'],
     'new-parens': 2,
     'no-caller': 2,

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ module.exports = {
     'eqeqeq': 2,
     'generator-star-spacing': 2,
     'indent': [2, 2, { 'SwitchCase': 1 }],
-    'key-spacing': [2, { 'beforeColon': false, 'afterColon': true, 'mode': 'minimum' }],
+    'key-spacing': [2, { 'beforeColon': false, 'afterColon': true, 'mode': 'strict' }],
     'linebreak-style': [2, 'unix'],
     'new-parens': 2,
     'no-arrow-condition': 2,


### PR DESCRIPTION
This is to prevent:

```js
const obj = {
  foo : 'bar'
};
```

The docs for this eslint rule is [here](http://eslint.org/docs/rules/key-spacing#options).