### PR TITLE
feat(browser): upgrade to ES6 rules

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -2,9 +2,10 @@
 
 module.exports = {
   env: {
-    'browser': true,
-    'mocha': true,
-    'protractor': true
+    'browser': true
   },
-  extends: 'lob/base'
+  extends: 'lob/index',
+  rules: {
+    'consistent-this': 0
+  }
 };


### PR DESCRIPTION
### What & Why

Enable ES6 rules for the browser so that those running with Babel can enforce good standards.