### PR TITLE
Disallow `new Function` (vector for eval)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.0 (2018-05-09)
+
+* **config**: enable no-new-func in error mode ([76daf6c](https://github.com/lob/eslint-config-lob/commit/76daf6ce917161bd6d8f8754bd7d13774437cffe))
+
 ## 3.0.0 (2017-11-13)
 
 ##### Chores

--- a/base.js
+++ b/base.js
@@ -57,6 +57,7 @@ module.exports = {
     'no-multiple-empty-lines': [2, { max: 1 }],
     'no-negated-in-lhs': 2,
     'no-new': 2,
+    'no-new-func': 2,
     'no-obj-calls': 2,
     'no-redeclare': [2, { 'builtinGlobals': true }],
     'no-regex-spaces': 2,


### PR DESCRIPTION
*What*: disallows the use of `new Function`, which can be another eval vector (we already have `no-eval` and `no-implied-eval` enabled).

Tested on lob-api and dashboard and there are no current usages / breakage