### PR TITLE
chore(align-equals): removing equal alignment to modernize rules

### DIFF
--- a/base.js
+++ b/base.js
@@ -3,7 +3,6 @@
 module.exports = {
   plugins: ['lob'],
   rules: {
-    'lob/align-equals': 2,
     'lob/newline-after-mocha': 2,
     'lob/padded-describes': 2,
     'array-bracket-spacing': [2, 'never'],
@@ -53,6 +52,7 @@ module.exports = {
     'no-lonely-if': 2,
     'no-loop-func': 2,
     'no-mixed-spaces-and-tabs': [2, 'smart-tabs'],
+    // 'no-multi-spaces': 2,
     'no-multi-str': 2,
     'no-multiple-empty-lines': [2, { max: 1 }],
     'no-negated-in-lhs': 2,


### PR DESCRIPTION
- This is Phase One of sorts
  - Left alignment on quotes is no longer enforced
  - They will still pass linter check, so will unaligned equals
  - Probably a Semver MINOR change (4.0.0 to 4.1.0)
- Phase Two is to enable the `no-multi-spaces` rule
  - This will require basically all JavaScript files to be updated
  - Such an update is easily done with `eslint --fix`, but will require rebases
  - Probaly a Semver MAJOR change (4.x to 5)

We would like to emphasize rapid iteration and deployment while retaining or increasing code confidence. To get there, we want to make linters less strict where appropriate, require every linter rule to provide an automatic fix, and have our code more closely resemble code found in the Node.js community to expedite on-boarding of engineers. With these requirements in mind we've decided to remove the alignment rule entirely. The linter rules have been [largely](https://github.com/lob/eslint-plugin-lob/commits/master) [untouched](https://github.com/lob/eslint-config-lob/commits/master) for the last few years, and now is a good time to start modernizing them.