### PR TITLE
Updates to support v7 of eslint

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -4,7 +4,7 @@ module.exports = {
   env: {
     'browser': true
   },
-  extends: 'lob/index',
+  extends: './index.js',
   rules: {
     'consistent-this': 0
   }

--- a/es5.js
+++ b/es5.js
@@ -5,5 +5,5 @@ module.exports = {
     'mocha': true,
     'node': true
   },
-  extends: 'lob/base'
+  extends: './base.js'
 };

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ module.exports = {
     'mocha': true,
     'node': true
   },
-  extends: 'lob/base',
+  extends: './base.js',
   rules: {
     'arrow-parens': 2,
     'arrow-spacing': 2,

--- a/migrations.js
+++ b/migrations.js
@@ -4,7 +4,7 @@ module.exports = {
   env: {
     'node': true
   },
-  extends: 'lob/index',
+  extends: './index.js',
   rules: {
     'no-shadow': [2, {
       'builtinGlobals': true,

--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
     "eslint-plugin-lob": "^1.0.1"
   },
   "devDependencies": {
-    "eslint": "^7.x",
+    "eslint": "^4.1",
     "generate-changelog": "^1.0.0"
   },
   "peerDependencies": {
-    "eslint": "^7.x"
+    "eslint": "^4.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
     "eslint-plugin-lob": "^1.0.1"
   },
   "devDependencies": {
-    "eslint": "^4.10.0",
+    "eslint": "^7.x",
     "generate-changelog": "^1.0.0"
   },
   "peerDependencies": {
-    "eslint": "4.x"
+    "eslint": "^7.x"
   }
 }


### PR DESCRIPTION
Was trying to use `eslint-config-lob` after realizing it exists, but I had already installed eslint 7 on my project -- and we currently require specifically version 4.0 as a peer package. Updated configuration to allow 4.0+; and updated `extends` syntax to not break with a `7.0.0` project.