### PR TITLE
Revert "updated version information for previous commit (pull/33)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 ### 5.0.0 (2020-07-24)
 
-* **relaxed peer eslint version** Change peer package requirement to allow newer versions of eslint. Updated syntax and verified compatibility with major versions 4-7.
-
-### 5.0.0 (2020-07-24)
-
 * **mixed &&s and ||s** change rules to disallow mixing operators.  Since this rule cannot be auto-fixed, this is a breaking change.
 
 ### 4.2.0 (2020-07-09)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-lob",
-  "version": "5.1.0",
+  "version": "4.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-lob",
-  "version": "5.1.0",
+  "version": "5.0.0",
   "description": "Shareable ESLint config for Lob repositories",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Was a bit greedy in committing without using proper changelog management scripts. Rolling back.