### PR TITLE
Rkofman/fix forward for pr 33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### 5.1.0 (2021-04-24)
+
+* **eslint:** Allow newer versions of eslint, and update syntax to work with major versions 4-7. (#33) ([bb3ec96](https://github.com/lob/eslint-config-lob/commit/bb3ec9655d5c187e87e334c65660a50618dedf4d))
+
+##### Chores
+
+* **deps:**  bump lodash from 4.17.15 to 4.17.19 ([e50e3bb6](https://github.com/lob/eslint-config-lob/commit/e50e3bb6954c767c765bb6402d92d98eaaf9ebbf))
+
 ### 5.0.0 (2020-07-24)
 
 * **mixed &&s and ||s** change rules to disallow mixing operators.  Since this rule cannot be auto-fixed, this is a breaking change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
-### 5.1.0 (2021-04-24)
+### 5.1.0 (2021-04-24) [DEPRECATED]
 
-* **eslint:** Allow newer versions of eslint, and update syntax to work with major versions 4-7. (#33) ([bb3ec96](https://github.com/lob/eslint-config-lob/commit/bb3ec9655d5c187e87e334c65660a50618dedf4d))
+* ~~**eslint:** Allow newer versions of eslint, and update syntax to work with major versions 4-7. (#33) ([bb3ec96](https://github.com/lob/eslint-config-lob/commit/bb3ec9655d5c187e87e334c65660a50618dedf4d))~~
 
 ##### Chores
 
 * **deps:**  bump lodash from 4.17.15 to 4.17.19 ([e50e3bb6](https://github.com/lob/eslint-config-lob/commit/e50e3bb6954c767c765bb6402d92d98eaaf9ebbf))
+
+##### Deprecation notes
+
+* This version attempted to allow eslint versions 4-7 as peer dependency. Due to a syntax mistake, it does not actually do so. Please use version 5.2.0 instead.
 
 ### 5.0.0 (2020-07-24)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-lob",
-  "version": "4.2.0",
+  "version": "5.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-lob",
-  "version": "5.1.0",
+  "version": "4.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-lob",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "Shareable ESLint config for Lob repositories",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "generate-changelog": "^1.0.0"
   },
   "peerDependencies": {
-    "eslint": "^4.1"
+    "eslint": ">=4.1 < 8"
   }
 }


### PR DESCRIPTION
Fixing forward for [pull/33](https://github.com/lob/eslint-config-lob/pull/33); and adding versioned releases to accompany the changes for publishing. Note: 5.1.0 was accidentally already published and must be included as a separate version.

In local testing, I had thought Pull/33 worked fine with `eslint` version 7; but it clearly pins the peer dependency at `4.x` rather than allowing `>=4.x` as was intended. In this round, I also added `<8` in case a future version introduces new breaking changes.